### PR TITLE
Revamp music session controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,23 +80,23 @@ h1 {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0,0,0,0.9);
+  background: linear-gradient(#ffffff, #cccccc);
   display: none;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: 0;
 }
 
 .modal-content {
-  border-radius: 16px;
+  border-radius: 0;
   padding: 20px;
   width: 100%;
   height: 100%;
   max-width: none;
   text-align: center;
-  color: #fff;
-  background: linear-gradient(135deg, #eeeeee, #ffffff);
+  color: #000;
+  background: linear-gradient(#ffffff, #cccccc);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -255,7 +255,7 @@ h1 {
 }
 
 .boxmusic.flash {
-  animation: flash-green 0.3s;
+  animation: flash-green 0.5s;
 }
 
 .main-header {


### PR DESCRIPTION
## Summary
- swap music reordering to double-tap with toggleable mode and visual cues
- add secret 1-2-3-2-1 box sequence to pause songs and swipe-triggered box flashes
- restyle modal overlay to full-screen white/gray gradient

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa31c2f1ec832598dc6d85e9308707