### PR TITLE
Lazy-load songs and remove item actions

### DIFF
--- a/Songs/index.html
+++ b/Songs/index.html
@@ -43,12 +43,6 @@
 
   <div id="music-overlay" class="music-overlay"></div>
   <div id="items-overlay" class="items-overlay"></div>
-  <div id="item-action-menu" class="item-action-menu">
-    <div class="menu-box">
-      <button onclick="selectItemAction('lavar')">Lavar</button>
-      <button onclick="selectItemAction('consertar')">Consertar</button>
-    </div>
-  </div>
   <div id="loader-overlay" class="loader-overlay">
     <div class="loader-circle">
       <svg width="150" height="150">

--- a/css/style.css
+++ b/css/style.css
@@ -225,6 +225,10 @@ h1 {
   transition: transform 0.3s;
 }
 
+.boxmusic.pending {
+  background: linear-gradient(#808080, #d3d3d3);
+}
+
 .boxmusic.playing {
   background: linear-gradient(#0e4cb8, #3470d4);
 }
@@ -303,8 +307,7 @@ h1 {
   transform: scale(1.05);
 }
 
-.items-overlay,
-.item-action-menu {
+.items-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -344,51 +347,6 @@ h1 {
   object-fit: contain;
 }
 
-.action-btn {
-  margin-top: 8px;
-  padding: 8px 12px;
-  border: none;
-  border-radius: 8px;
-  color: #fff;
-  font-weight: bold;
-  cursor: default;
-}
-
-.action-btn.lavar {
-  background: linear-gradient(135deg, #1e90ff, #00bfff);
-}
-
-.action-btn.consertar {
-  background: linear-gradient(135deg, #ff8c00, #ffa500);
-}
-
-.item-action-menu .menu-box {
-  background: #fff;
-  color: #000;
-  padding: 20px;
-  border-radius: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.item-action-menu button {
-  padding: 10px 20px;
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  font-weight: bold;
-}
-
-.item-action-menu .lavar-btn {
-  background: linear-gradient(135deg, #1e90ff, #00bfff);
-  color: #fff;
-}
-
-.item-action-menu .consertar-btn {
-  background: linear-gradient(135deg, #ff8c00, #ffa500);
-  color: #fff;
-}
 
 .loader-overlay {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -43,12 +43,6 @@
 
   <div id="music-overlay" class="music-overlay"></div>
   <div id="items-overlay" class="items-overlay"></div>
-  <div id="item-action-menu" class="item-action-menu">
-    <div class="menu-box">
-      <button class="lavar-btn" onclick="selectItemAction('lavar')">Lavar</button>
-      <button class="consertar-btn" onclick="selectItemAction('consertar')">Consertar</button>
-    </div>
-  </div>
   <div id="loader-overlay" class="loader-overlay">
     <div class="loader-circle">
       <svg width="150" height="150">


### PR DESCRIPTION
## Summary
- Cache only image assets on startup and defer song downloads until requested.
- Remove four-tap item action menu for "lavar"/"consertar" and simplify item toggling.
- Start music boxes in grey, downloading tracks on demand with color-based progress and local storage caching.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabaddb8c08325959acaf4342f71f0