### PR TITLE
Preload assets and remove music buffer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -247,16 +247,6 @@ h1 {
   margin-top: 5px;
 }
 
-.music-buffer-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  background: green;
-  opacity: 0.5;
-  width: 0%;
-}
-
 .music-progress-bar {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- preload all songs and item assets on startup with a new cacheAssets function
- show a 10s fake loader animation before real download progress
- remove music buffer UI for simpler playback

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aac4d356b483258fa630c8dfaed375